### PR TITLE
Deprecate styling

### DIFF
--- a/include/nvdialog_css_manager.h
+++ b/include/nvdialog_css_manager.h
@@ -33,14 +33,8 @@
 #endif /* __nvdialog_h__ */
 
 /**
- * @brief An enumerator to get the CSS provider for the CSS API
- * of NvDialog.
- * @details The CSS provider (Backend) is the service behind NvDialog's
- * CSS API implementation, almost always tied to the backend available.
- * In order to get the full customization capabilities, you can query
- * which CSS provider is being used by NvDialog, then write provider-specific
- * configuration to allow for customization.
- * @note The CSS backend is not available for the WinAPI.
+ * @deprecated Styling support has been dropped from 0.7.0 onwards.
+ * This is because it created large cross-platform problems for developers.
  */
 typedef enum {
         NVD_GTK3_CSS_BACKEND = 0xdd, /* Gtk3 CSS Backend. */
@@ -49,54 +43,34 @@ typedef enum {
 } NvdCSSBackend;
 
 /**
- * @brief The CSS manager for NvDialog. 
- * @details The CSS manager is responsible for using a custom stylesheet
- * on dialogs, by attaching the stylesheet to the raw handle of the dialog.
- * @note The CSS manager is *NOT* thread-safe. Only use it from the main thread.
+ * @deprecated First deprecated in v0.7.0, the CSS styling support
+ * was dropped. If your application uses it, try limiting it before
+ * v0.8.0 is released (Which is when all deprecated code will be removed).
  */
 typedef struct _NvdCSSManager NvdCSSManager;
 
 /**
- * @brief Returns the @ref NvdCSSBackend.
- * @return The CSS backend used as an enumerator.
+ * @deprecated Styling support has been dropped, hence this function is invalid.
  */
 NVD_API NvdCSSBackend nvd_get_css_backend(void);
 
 /**
- * @brief Returns a new NvdCSSManager.
- * @details This function is used to instantiate a new NvdCSSManager into
- * your application, by returning a pointer to the new instance created by
- * this function.
- * @note You only need a single instance of the manager. All changes are program-wide,
- * and will be reflected in every dialog created.
- * @return An empty, initialized @ref NvdCSSManager.
+ * @deprecated CSS support has been deprecated. Avoid using deprecated code.
  */
 NVD_API NvdCSSManager* nvd_css_manager_new(void);
 
 /**
- * @brief Attaches a CSS stylesheet from the 'str' parameter given below.
- * @param mgr The manager to attach the stylesheet to.
- * @param str A string representation of a stylesheet.
- * @note This creates a file and writes 'str' to it, then loads the file into
- * the CSS backend. As a result, it may cause your application to halt for a bit.
- * Prefer using a file instead.
- * @return 0 if succesful, otherwise -1 and sets the error code. See @ref nvd_get_error for details.
+ * @deprecated Styling support has been deprecated from v0.7.0 onwards.
  */
 NVD_API int nvd_css_manager_attach_string_stylesheet(NvdCSSManager *mgr, const char *str);
 
 /**
- * @brief Attaches a CSS stylesheet from the specified filename.
- * @param mgr The manager to use.
- * @param filename The filename of the stylesheet file to parse and attach.
- * @return int 
+ * @deprecated Styling support has been deprecated from v0.7.0 onwards.
  */
 NVD_API int nvd_css_manager_attach_stylesheet(NvdCSSManager *mgr, const char *filename);
 
 /**
- * @brief Uses the stylesheet attached to the manager for the dialog specified.
- * @param mgr The manager to use.
- * @param raw_handle Returned from an object-specific function as the backend object.
- * @return 0 on success, otherwise -1 and sets the error code. See @ref nvd_get_error.
+ * @deprecated Styling support has been deprecated from v0.7.0 onwards.
  */
 NVD_API int nvd_css_manager_use_style(NvdCSSManager *mgr, void *raw_handle);
 #endif /* __nvdialog_css_manager_h__ */

--- a/src/backend/adw/nvdialog_css_manager.c
+++ b/src/backend/adw/nvdialog_css_manager.c
@@ -42,55 +42,18 @@ static char *__nvd_string_gen(char *str, size_t size) {
 }
 
 NvdCSSManager *nvd_css_manager_adw() {
-        /* Only using calloc() here because I don't want to assign NULL everywhere :P */
-        NvdCSSManager *mgr = calloc(1, sizeof(struct _NvdCSSManager));
-        NVD_RETURN_IF_NULL(mgr);
-
-        mgr->raw  = gtk_css_provider_new();
-        mgr->used = false;
-
-        return mgr;
+        return NULL;
 }
 
 int nvd_css_manager_attach_string_stylesheet_adw(NvdCSSManager *mgr,
                                                  const char    *str) {
-        int32_t chdir_result = chdir("/tmp"); /* So we don't harm anything we shouldn't. */
-        if (chdir_result != 0) {
-                nvd_set_error(NVD_FILE_INACCESSIBLE);
-                return -1;
-        }
-
-        char *new_filename = calloc(1, sizeof(char) * 13);
-        __nvd_string_gen(new_filename, 12);
-
-        FILE *stream = fopen(new_filename, "w");
-        fputs (str, stream);
-        fclose(stream);
-
-        char filename[NVDIALOG_MAXBUF];
-        sprintf(filename, "%s%s", "/tmp/", new_filename);
-
-        gtk_css_provider_load_from_path ((GtkCssProvider*) mgr->raw,
-                                                      filename);
-        /*
-         * Well, we could store it in 'mgr' but then why even create a random
-         * string for its filename?
-         */
-        free(new_filename);
-        return 0;
+        return -1;
 }
 
 int nvd_css_manager_attach_stylesheet_adw(NvdCSSManager *mgr, const char *filename) {
-        gtk_css_provider_load_from_path(mgr->raw,
-                                        filename);
-        return 0;
+        return -1;
 }
 
 int nvd_css_manager_use_style_adw(NvdCSSManager *mgr, void *raw_handle) {
-        gtk_style_context_add_provider(
-                gtk_widget_get_style_context(GTK_WIDGET(raw_handle)),
-                mgr->raw,
-                GTK_STYLE_PROVIDER_PRIORITY_USER
-        );
-        return 0;
+        return -1;
 }

--- a/src/backend/gtk/nvdialog_css_manager.c
+++ b/src/backend/gtk/nvdialog_css_manager.c
@@ -44,66 +44,18 @@ static char *__nvd_string_gen(char *str, size_t size) {
 }
 
 NvdCSSManager *nvd_css_manager_gtk() {
-        /* Only using calloc() here because I don't want to assign NULL everywhere :P */
-        NvdCSSManager *mgr = calloc(1, sizeof(struct _NvdCSSManager));
-        NVD_RETURN_IF_NULL(mgr);
-
-        mgr->raw  = gtk_css_provider_new();
-        mgr->used = false;
-
-        return mgr;
+        return NULL;
 }
 
 int nvd_css_manager_attach_string_stylesheet_gtk(NvdCSSManager *mgr,
                                                  const char    *str) {
-        int chdir_result = chdir("/tmp");
-        if (chdir_result != 0) {
-                NVD_ASSERT(chdir_result != 0);
-                return errno;
-        }
-
-        char *new_filename = calloc(1, sizeof(char) * 13);
-        __nvd_string_gen(new_filename, 12);
-
-        FILE *stream = fopen(new_filename, "w");
-        fputs (str, stream);
-        fclose(stream);
-
-        char filename[NVDIALOG_MAXBUF];
-        sprintf(filename, "%s%s", "/tmp/", new_filename);
-
-        bool result = gtk_css_provider_load_from_path ((GtkCssProvider*) mgr->raw,
-                                                      filename,
-                                                      NULL);
-        if (!result) {
-                nvd_set_error(NVD_INTERNAL_ERROR);
-                free(new_filename);
-                return -1;
-        }
-        /*
-         * Well, we could store it in 'mgr' but then why even create a random
-         * string for its filename?
-         */
-        free(new_filename);
-        return 0;
+        return -1;
 }
 
 int nvd_css_manager_attach_stylesheet_gtk(NvdCSSManager *mgr, const char *filename) {
-        bool result = gtk_css_provider_load_from_path(mgr->raw,
-                                                      filename,
-                                                      NULL);
-        if (!result) {
-                nvd_set_error(NVD_INTERNAL_ERROR);
-                return -1;
-        }
-        return 0;
+        return -1;
 }
 
 NVD_FORCE_INLINE int nvd_css_manager_use_style_gtk(NvdCSSManager *mgr, void *raw_handle) {
-        gtk_style_context_add_provider(
-                gtk_widget_get_style_context(GTK_WIDGET(raw_handle)),
-                mgr->raw,
-                GTK_STYLE_PROVIDER_PRIORITY_USER
-        );
-        return 0;
+        return -1;
 }


### PR DESCRIPTION
## Prelude
Styling support in NvDialog was added in [v0.5.0](#31) for better integration with Gtk3 and for GNU/Linux developers to use their app's theme (In request of https://stopthemingmy.app). This worked, but it was actually a hassle for cross-platform support. Imagine this code:
```cpp
NvdCSSManager* mgr = nvd_css_manager_new();
if (nvd_css_manager_attach_string_stylesheet(mgr, "css code here") != 0)
    exit(EXIT_FAILURE);
else nvd_css_manager_use_style(*mgr, NULL);
```
This:
- **May work on macOS X**, depending on the backend.
- Will 99% work on GNU/Linux
- Will **definitely not work** on Windows.

You see, Cocoa, the WinAPI and Gtk have nothing in common when it comes to styling, meaning NvDialog never bothered to work for those platforms. In addition, the reason NvDialog is called NvDialog is just a corruption of the words "Native Dialogs". In other words, CSS styling shouldn't be here in the first place, and removing it seems natural.

This pull request will be a two stage merge, the first one to deprecate code and add compiler warnings, and the second one to completely remove the code, targeted for the v0.8.0 release.

## TODOs
- [x] Mark related functions as deprecated
- [x] Remove the implementations directly and replace them with error returns (NULL, -1, ...)
- [x] Update documentation

**Stage 2**
- [ ] Remove implementations entirely (Only allow them to be available during linking, but no contents within the functions).
- [ ] Remove declarations from header files.
- [ ] Remove functions entirely (v0.8.0)