### PR TITLE
Add distribution-specific code to NvDialog

### DIFF
--- a/src/nvdialog_util.c
+++ b/src/nvdialog_util.c
@@ -29,6 +29,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #ifdef _WIN32
@@ -161,4 +162,22 @@ NVD_INTERNAL_FUNCTION NvdDistroInfo nvd_get_distro_branch() {
     } else info.name = "Unknown";
     
     return info;
+}
+
+NVD_INTERNAL_FUNCTION char* nvd_get_libnotify_path() {
+    size_t max_pathlen = strlen("/usr/lib/x86_64-linux-gnu/libnotify.so");
+    char* buffer = malloc(max_pathlen + 16); // 16 byte padding
+    NVD_ASSERT_FATAL(buffer != NULL);
+
+    NvdDistroInfo info = nvd_get_distro_branch();
+
+    /* TODO: Please add more distribution checks here.*/
+    if (strcmp(info.name, "Debian") == 0)
+        strcpy(buffer, "/usr/lib/x86_64-linux-gnu/libnotify.so");
+    else if (strcmp(info.name, "Arch") == 0)
+        strcpy(buffer, "/usr/lib/libnotify.so");
+    else
+        strcpy(buffer, "/usr/lib/libnotify.so");
+
+    return buffer;
 }

--- a/src/nvdialog_util.c
+++ b/src/nvdialog_util.c
@@ -142,6 +142,11 @@ NVD_INTERNAL_FUNCTION NvdDistroInfo nvd_get_distro_branch() {
     NvdDistroInfo info;
     nvd_zero_memory(&info, sizeof(NvdDistroInfo));
 
+    #if !defined(__linux__) && !defined(__linux) && !defined (__gnu_linux__)
+    /* Yes we don't have a pointer here so we can't return NULL, so let's just return a zeroed-out struct instead. */
+    return info;
+    #endif
+
     /* We call nvd_read_os_release in each block separately since we also support rolling release distros. */
     if (nvd_file_exists("/etc/debian_version")) {
         info.name = "Debian";

--- a/src/nvdialog_util.c
+++ b/src/nvdialog_util.c
@@ -23,8 +23,51 @@
  */
 
 #include "nvdialog_util.h"
+#include "nvdialog_assert.h"
+#include "nvdialog_error.h"
+#include "nvdialog_macros.h"
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+
+#ifdef _WIN32
+#include <io.h>
+#define access _access
+#else
+#include <unistd.h> // access()
+#endif
+
+// TODO
+static inline bool nvd_file_exists(const char* path) {
+    return (access(path, 0) == 0);
+}
+
+/**
+ * @brief Writes @ref size bytes to @ref ptr to ensure proper initialization.
+ * @param ptr A pointer to the data structure where the NULL bytes will be written.
+ * @param size The amount of NULL bytes to write before stopping.
+ */
+static void nvd_zero_memory(void* ptr, size_t size) {
+    memset(ptr, 0, size);
+}
+
+#if defined (__linux__) || defined (__linux) || defined (__gnu_linux__)
+static void nvd_read_os_release(NvdDistroInfo* info) {
+    FILE *file = fopen("/etc/os-release", "r");
+    NVD_ASSERT(file != NULL);
+
+    char line[NVD_BUFFER_SIZE];
+    while (fgets(line, sizeof(line), file)) {
+        if (strstr(line, "VERSION_ID=")) {
+            if (sscanf(line, "VERSION_ID=\"%ld", &info->version_m) == 1) {
+                fclose(file);
+                break;
+            }
+        }
+    }
+}
+#endif /* __linux__ */
 
 NvdProcessID nvd_create_process(void) {
     #if defined (unix) || defined(__APPLE__)
@@ -93,4 +136,24 @@ char** nvd_seperate_args(const char* str) {
     words[i] = NULL;
     
     return words;
+}
+
+NVD_INTERNAL_FUNCTION NvdDistroInfo nvd_get_distro_branch() {
+    NvdDistroInfo info;
+    nvd_zero_memory(&info, sizeof(NvdDistroInfo));
+
+    /* We call nvd_read_os_release in each block separately since we also support rolling release distros. */
+    if (nvd_file_exists("/etc/debian_version")) {
+        info.name = "Debian";
+        nvd_read_os_release(&info);
+    } else if (nvd_file_exists("/etc/pacman.conf")) {
+        info.name = "Arch";
+        info.version_m = -1; // Rolling release
+        info.version_s = -1;
+    } else if (nvd_file_exists("/etc/dnf/dnf.conf")) {
+        info.name = "Fedora";
+        nvd_read_os_release(&info);
+    } else info.name = "Unknown";
+    
+    return info;
 }

--- a/src/nvdialog_util.h
+++ b/src/nvdialog_util.h
@@ -41,7 +41,7 @@
 
 /**
  * @brief A data structure to hold information about a Linux
- * distribution. It should be returned by @ref nvd_get_distribution_info 
+ * distribution. It should be returned by @ref nvd_get_distribution_info;
  */
 typedef struct _NvdDistroInfo {
     char* name;
@@ -103,5 +103,14 @@ char** nvd_seperate_args(const char* str);
  * or NULL if there is a failure (Will set the error accordingly unless not on GNU/Linux).
  */
 NvdDistroInfo nvd_get_distro_branch();
+
+/**
+ * @brief Returns the path to `libnotify` on the system for `dlopen`.
+ * @note Linux-only function, will not work on Windows/macOS. The pointer returned was dynamically allocated
+ * and hence should be freed using `free()`.
+ *
+ * @return The path to libnotify on each platform if succesfull, otherwise NULL.
+ */
+char* nvd_get_libnotify_path();
 
 #endif /* __nvdialog_util_h__ */

--- a/src/nvdialog_util.h
+++ b/src/nvdialog_util.h
@@ -40,6 +40,16 @@
 #endif /* NVD_PLATFORM_UNIX */
 
 /**
+ * @brief A data structure to hold information about a Linux
+ * distribution. It should be returned by @ref nvd_get_distribution_info 
+ */
+typedef struct _NvdDistroInfo {
+    char* name;
+    long version_m;
+    long version_s;
+} NvdDistroInfo;
+
+/**
  * @brief An identifier to match a new process ID spawned by @ref nvd_create_process
  * @details Similar to the `pid_t` type (And similarly defined), this type
  * keeps the process ID for a forked process.
@@ -84,5 +94,14 @@ bool nvd_is_sandboxed(void);
  * there was an error allocating memory.
  */
 char** nvd_seperate_args(const char* str);
+
+/**
+ * @brief Returns the distribution information on Linux, lik
+ * @note This function will return NULL if the OS is not GNU/Linux. It will also only return data related
+ * to the base of the distribution, NOT the exact distribution you're running (eg. on Ubuntu you will get Debian).
+ * @return A @ref NvdDistroInfo filled out with all the necessary information,
+ * or NULL if there is a failure (Will set the error accordingly unless not on GNU/Linux).
+ */
+NvdDistroInfo nvd_get_distro_branch();
 
 #endif /* __nvdialog_util_h__ */


### PR DESCRIPTION
This is part of fixing #44 on Linux. Note that these functions aren't used yet on the library itself, so a follow up MR will follow soon.