### PR TITLE
Fix dialog box being stuck on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Increased shared file version to 2 (Output files may contain libnvdialog.so.2 now)
 - Fixed libnotify not loading on Linux (See #44 for details)
 - Fixed a bug where NvDialog would abort the entire process despite no failure happening.
+- Fixed dialog not disappearing after pressing the accept button (See #42)
 
 # Changelog -- 0.7.0
 - Gtk dialogs will now be guaranteed to have their title set.

--- a/src/backend/cocoa/nvdialog_dialog_box.m
+++ b/src/backend/cocoa/nvdialog_dialog_box.m
@@ -37,7 +37,7 @@ NvdDialogBox *nvd_dialog_box_cocoa(const char *title, const char *message, NvdDi
 void nvd_show_dialog_cocoa(NvdDialogBox *dialog)
 {
 	[dialog->window_handle runModal];
-	[dialog->window_handle release];
+	[dialog->window_handle orderOut];
 }
 
 void *nvd_dialog_box_get_raw_cocoa(NvdDialogBox *dlg)


### PR DESCRIPTION
Closes #42 

This is **not** verified outside of compilation and may not work properly.