### PR TITLE
(DRAFT) Create new string API and apply it in the source code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This file is part of libnvdialog and is released under the MIT license.
 
 cmake_minimum_required(VERSION 3.18)
-project(libnvdialog VERSION 0.9.0 LANGUAGES C DESCRIPTION "A simple and minimal dialog library, with cross-platform support")
+project(libnvdialog VERSION 0.10.0 LANGUAGES C DESCRIPTION "A simple and minimal dialog library, with cross-platform support")
 
 option(CROSS_COMPILE_FOR_WIN32 "Cross-compile the library for Windows from Linux." OFF)
 option(NVD_USE_GTK4 "Use Gtk4 and libadwaita instead of Gtk3 (experimental)." OFF)
@@ -44,6 +44,7 @@ set(NVD_HEADERS
     include/nvdialog_error.h
     include/nvdialog_platform.h
     include/nvdialog_image.h
+    include/nvdialog_string.h
     include/nvdialog.h)
 
 set(NVD_EXTRA_HEADERS
@@ -58,6 +59,7 @@ set(NVD_COMMON_SOURCES
     src/nvdialog_capab.c
     src/nvdialog_version.c
     src/nvdialog_init.c
+    src/nvdialog_string.c
     src/nvdialog_main.c)
 
 if(WIN32 OR CROSS_COMPILE_FOR_WIN32)

--- a/include/dialogs/nvdialog_file_dialog.h
+++ b/include/dialogs/nvdialog_file_dialog.h
@@ -22,6 +22,7 @@
  * IN THE SOFTWARE.
  */
 
+#include "../nvdialog_string.h"
 #include "../nvdialog_platform.h"
 
 /**
@@ -82,7 +83,7 @@ NVD_API NvdFileDialog *nvd_open_folder_dialog_new(const char *title,
  * @brief Returns the filesystem path chosen through the @ref NvdFileDialog
  * passed.
  *
- * This function will return the path on the filesystem from the dialog chosen,
+ * @details This function will return the path on the filesystem from the dialog chosen,
  * that you can then use to either open or save the file given. It works with
  * both save and open file dialog types.
  *
@@ -90,9 +91,10 @@ NVD_API NvdFileDialog *nvd_open_folder_dialog_new(const char *title,
  * @param dialog The file dialog to take the filename from.
  * @param savebuf A pointer to a buffer where the path will be written, must not
  * be NULL.
+ * @returns A @ref NvdDynamicString if a file/folder was selected, or NULL if no path was selected by the user.
  * @ingroup FileDialog
  */
-NVD_API void nvd_get_file_location(NvdFileDialog *dialog, const char **savebuf);
+NVD_API NvdDynamicString* nvd_get_file_location(NvdFileDialog *dialog);
 
 /**
  * @brief Returns the raw object behind the dialog.

--- a/include/nvdialog_build.h
+++ b/include/nvdialog_build.h
@@ -25,8 +25,8 @@
 /************************************************************************************
  * This file is NOT source code. It will just be used by Doxygen when
  * generating documentation for the "Building NvDialog" page. It won't be
- *installed, it won't be used within the library or by a user, and probably
- *isn't of interest to anyone.
+ * installed, it won't be used within the library or by a user, and probably
+ * isn't of interest to anyone.
  ************************************************************************************/
 
 /**

--- a/include/nvdialog_capab.h
+++ b/include/nvdialog_capab.h
@@ -22,20 +22,13 @@
  * IN THE SOFTWARE.
  */
 
-#include "nvdialog.h"
-#ifdef __nvdialog_capab_h__
-#error[ NVDIALOG ] Header file included twice, only include <nvdialog/nvdialog.h>
-#endif /* __nvdialog_capab_h__ */
 
 #pragma once
 #ifndef __nvdialog_capab_h__
 #define __nvdialog_capab_h__ 1
 
 #include <stdbool.h>
-
-#ifndef __nvdialog_h__
-#error[ NVDIALOG ] Please only include <nvdialog.h> and no other headers.
-#endif /* __nvdialog_h__ */
+#include "nvdialog_platform.h"
 
 enum {
         /* Adwaita backend support */

--- a/include/nvdialog_core.h
+++ b/include/nvdialog_core.h
@@ -24,19 +24,11 @@
 
 #pragma once
 
-#include "nvdialog.h"
-#ifdef __nvdialog_core_h__
-#error[ NVDIALOG ] Header file included twice, only #include <nvdialog/nvdialog.h>
-#endif /* __nvdialog_core_h__ */
-
 #ifndef __nvdialog_core_h__
 #define __nvdialog_core_h__ 1
 
-#ifndef __nvdialog_h__
-#error[ NVDIALOG ] Please only include <nvdialog.h> and no other headers.
-#endif /* __nvdialog_h__ */
-
 #include "nvdialog_types.h"
+#include "nvdialog_platform.h"
 
 /** @brief An opaque representation of a window object. */
 typedef void *NvdParentWindow;

--- a/include/nvdialog_dialog.h
+++ b/include/nvdialog_dialog.h
@@ -24,20 +24,11 @@
 
 #pragma once
 
-#ifdef __nvdialog_dialog_h__
-#error[ NVDIALOG ] Header file included twice, only include <nvdialog/nvdialog.h>
-#endif /* __nvdialog_dialog_h__ */
-
 #ifndef __nvdialog_dialog_h__
 #define __nvdialog_dialog_h__ 1
-
-#ifndef __nvdialog_h__
-#error[ NVDIALOG ] Please only include <nvdialog.h> and no other headers.
-#endif /* __nvdialog_h__ */
 
 #include "dialogs/nvdialog_about_dialog.h"
 #include "dialogs/nvdialog_dialog_box.h"
 #include "dialogs/nvdialog_file_dialog.h"
-#include "nvdialog_platform.h"
 
 #endif /* __nvdialog_dialog_h__ */

--- a/include/nvdialog_error.h
+++ b/include/nvdialog_error.h
@@ -24,17 +24,29 @@
 
 #pragma once
 
-#include "nvdialog.h"
-#ifdef __nvdialog_error_h__
-#error[ NVDIALOG ] Header file included twice, only include <nvdialog/nvdialog.h>
-#endif /* __nvdialog_error_h__ */
-
 #ifndef __nvdialog_error_h__
 #define __nvdialog_error_h__ 1
 
-#ifndef __nvdialog_h__
-#error[ NVDIALOG ] Please only include <nvdialog.h> and no other headers.
-#endif /* __nvdialog_h__ */
+#include "nvdialog_platform.h"
+
+/**
+ * @brief The enumerator containing most
+ * errors the library can handle.
+ * @sa @ref nvd_stringify_error
+ */
+typedef enum {
+        NVD_NO_ERROR = 0,
+        NVD_NO_DISPLAY = 0xff,
+        NVD_BACKEND_FAILURE,
+        NVD_INVALID_PARAM,
+        NVD_NOT_INITIALIZED,
+        NVD_BACKEND_INVALID,
+        NVD_FILE_INACCESSIBLE,
+        NVD_STRING_EMPTY,
+        NVD_OUT_OF_MEMORY,
+        NVD_INTERNAL_ERROR,
+        NVD_ALREADY_INITIALIZED,
+} NvdError;
 
 /**
  * @brief Returns the current error code of the library.

--- a/include/nvdialog_error.h
+++ b/include/nvdialog_error.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "nvdialog_string.h"
 #ifndef __nvdialog_error_h__
 #define __nvdialog_error_h__ 1
 
@@ -36,7 +37,7 @@
  */
 typedef enum {
         NVD_NO_ERROR = 0,
-        NVD_NO_DISPLAY = 0xff,
+        NVD_NO_DISPLAY,
         NVD_BACKEND_FAILURE,
         NVD_INVALID_PARAM,
         NVD_NOT_INITIALIZED,
@@ -64,11 +65,10 @@ NVD_API NvdError nvd_get_error(void);
 /**
  * @brief Transforms an error code into a string representation, that can be
  * used to print errors to the console.
- * @returns The string representation of the error, or NULL on failure.
+ * @returns A @ref NvdDynamicString containing the error as a string, or NULL in case of failure or invalid parameter.
  * @ingroup Error
- * @note The string returned is saved inside the function as static, and each
- * call simply overwrites it.
+ * @note Pre v0.10 code may not work with this function due to different return types.
  */
-NVD_API const char *nvd_stringify_error(NvdError err);
+NVD_API NvdDynamicString *nvd_stringify_error(NvdError err);
 
 #endif /* __nvdialog_error_h__ */

--- a/include/nvdialog_image.h
+++ b/include/nvdialog_image.h
@@ -24,22 +24,15 @@
 
 #pragma once
 
-#ifdef __nvdialog_image_h__
-#error[ NVDIALOG ] Header file included twice, only #include <nvdialog/nvdialog.h>
-#endif /* __nvdialog_image_h__ */
 
 #ifndef __nvdialog_image_h__
 #define __nvdialog_image_h__ 1
 
 #include <stddef.h>
 #include <stdint.h>
-
-#include "nvdialog.h"
+#include "nvdialog_platform.h"
 #include "nvdialog_types.h"
 
-#ifndef __nvdialog_h__
-#error[ NVDIALOG ] Please only include <nvdialog.h> and no other headers.
-#endif /* __nvdialog_h__ */
 
 /**
  * @brief Data that can be interpeted as an image.

--- a/include/nvdialog_notification.h
+++ b/include/nvdialog_notification.h
@@ -24,13 +24,10 @@
 
 #pragma once
 
-#include "nvdialog.h"
 #ifndef __nvdialog_notification_h__
 #define __nvdialog_notification_h__ 1
 
-#ifndef __nvdialog_h__
-#error[ NVDIALOG ] Please only include <nvdialog.h> and no other headers.
-#endif /* __nvdialog_h__ */
+#include "nvdialog_platform.h"
 
 /**
  * @brief Possible types of NvDialog notifications. Each field will create a

--- a/include/nvdialog_string.h
+++ b/include/nvdialog_string.h
@@ -1,0 +1,137 @@
+/*
+ *  The MIT License (MIT)
+ *
+ *  Copyright (c) 2025 Aggelos Tselios
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#ifndef __nvdialog_string_h__
+#define __nvdialog_string_h__ 1
+
+#include <stddef.h>
+#include "nvdialog_platform.h"
+
+/**
+ * @brief A string type that can be resized, manipulated, converted and read from.
+ * 
+ * `NvdDynamicString` is a recent addition to the library that allows various kinds of strings
+ * across various operating systems to be abstracted and represented by a single type. Whereas `const char*` is
+ * widely used throughout the library, an `NvdDynamicString` is useful when strings are returned - Simple character literals cannot
+ * be returned since they are allocated on the stack. It is also simple to use and convert from and to `char` buffers, making it
+ * compatible with almost all existing APIs.
+ * @note Do not pass this to any parameters that require a `char*` without explicit conversion (See `nvd_string_to_cstr()`).
+ * @note Internally, this dynamic string maintains a capacity variable, that may allocate more memory than needed to store the string. This is done to avoid multiple allocations.
+ * @since v0.10.0
+ * @ingroup String
+*/
+typedef struct _NvdDynamicString NvdDynamicString;
+
+/**
+ * @brief Creates a new @ref `NvdDynamicString` and returns it, optionally with the data given in `contents`.
+ * @param data A C-style string to convert into a dynamic string, optional. Pass NULL to create an empty `NvdDynamicString`.
+ * @returns A new `NvdDynamicString` on success, otherwise `NULL` and the internal error code is set.
+ * @since v0.10.0
+ * @ingroup String
+*/
+NVD_API NvdDynamicString *nvd_string_new(const char *data);
+
+/**
+ * @brief Sets the actual string inside the given @ref `NvdDynamicString`.
+ * @param string The @ref `NvdDynamicString` to modify.
+ * @param data The string to set as the contents of the `NvdDynamicString`.
+ * @note This will discard any existing data in the string. If you wish to simply append @ref data to the string, see @ref nvd_append_to_string
+ * @since v0.10.0
+ * @ingroup String
+*/
+
+NVD_API void nvd_string_set_data(NvdDynamicString *string, const char *data);
+
+/**
+ * @brief Duplicates the given @ref `NvdDynamicString` without modifying it.
+ *
+ * You might find this useful when you wish to give the duplicated string in a function that needs to temporarily modify it,
+ * or simply modify the string yourself without losing the original contents.
+ * In most cases, reusing the same string is enough.
+ * @param other The string to copy from.
+ * @note The returned object is completely unique from @ref other and any modifications in one won't impact the other.
+ * @since v0.10.0
+ * @ingroup String
+ */
+NVD_API NvdDynamicString *nvd_duplicate_string(NvdDynamicString *other);
+
+/**
+ * @brief Appends the contents of `new_data` to the end of `string`.
+ * @param string The `NvdDynamicString` to append to. Must not be `NULL`.
+ * @param new_data The string whose contents will be appended. Must not be `NULL`.
+ * @note This function automatically resizes `string` if needed.
+ * @since v0.10.0
+ * @ingroup String
+*/
+NVD_API void nvd_append_to_string(NvdDynamicString *string, NvdDynamicString *new_data);
+
+/**
+ * @brief Returns a `const char*` representation of the given `NvdDynamicString`.
+ * @param string The `NvdDynamicString` to convert. Must not be `NULL`.
+ * @returns A pointer to a null-terminated C string. The pointer is valid as long as the dynamic string exists and is not modified.
+ * @note Do not modify or free the returned pointer, as it may be used elsewhere. Use `nvd_duplicate_string()` if a mutable copy is needed.
+ * @since v0.10.0
+ * @ingroup String
+*/
+NVD_API const char *nvd_string_to_cstr(NvdDynamicString *string);
+
+/**
+ * @brief Preallocates memory for at least `bytes` inside the @ref string 's data. No data will be lost.
+ * @param string The string to increase the capacity of.
+ * @param bytes The minimum number of bytes to reserve.
+ * @note While optional and implicitly done internally when extra space is needed, this can help with performance if you know the size of the data that must be appended.
+ * @since v0.10.0
+ * @ingroup String
+*/
+NVD_API void nvd_string_reserve(NvdDynamicString *string, size_t bytes);
+
+/**
+ * @brief Returns the length of the given `NvdDynamicString`.
+ * @param string The string whose length will be measured. Must not be `NULL`.
+ * @returns The number of characters in the string, excluding the null-terminator.
+ * @since v0.10.0
+ * @ingroup String
+*/
+NVD_API size_t nvd_strlen(NvdDynamicString *string);
+
+/**
+ * @brief Clears the contents of the given `NvdDynamicString`.
+ * @param string The string to clear. Must not be `NULL`.
+ * @note Any data inside will be lost, but no additional (re)allocations will be performed.
+ * @since v0.10.0
+ * @ingroup String
+*/
+NVD_API void nvd_string_clear(NvdDynamicString *string);
+/**
+ * @brief Deletes the string from memory and casts it invalid to use.
+ * @note For security and safety reasons, all the data of the pointer will be zeroed-out first.
+ * @param string The string to delete. This function does nothing if @ref `string` is `NULL`
+ * @since v0.10.0
+ * @ingroup String
+*/
+NVD_API void nvd_delete_string(NvdDynamicString *string);
+
+#endif /* __nvdialog_string_h__ */

--- a/include/nvdialog_types.h
+++ b/include/nvdialog_types.h
@@ -24,10 +24,6 @@
 
 #pragma once
 
-#ifdef __nvdialog_types_h__
-#error[ NVDIALOG ] Header file included twice, only include <nvdialog/nvdialog.h>
-#endif /* __nvdialog_types_h__ */
-
 #ifndef __nvdialog_types_h__
 #define __nvdialog_types_h__ 1
 
@@ -45,25 +41,6 @@ typedef enum {
                                warning color styling. */
         NVD_DIALOG_ERROR,   /**< An error message box, with error styling. */
 } NvdDialogType;
-
-/**
- * @brief The enumerator containing most
- * errors the library can handle.
- * @sa @ref nvd_stringify_error
- */
-typedef enum {
-        NVD_NO_ERROR = 0,
-        NVD_NO_DISPLAY = 0xff,
-        NVD_BACKEND_FAILURE,
-        NVD_INVALID_PARAM,
-        NVD_NOT_INITIALIZED,
-        NVD_BACKEND_INVALID,
-        NVD_FILE_INACCESSIBLE,
-        NVD_STRING_EMPTY,
-        NVD_OUT_OF_MEMORY,
-        NVD_INTERNAL_ERROR,
-        NVD_ALREADY_INITIALIZED,
-} NvdError;
 
 /**
  * @brief Enumerator containing the possible arguments for

--- a/src/backend/cocoa/nvdialog_cocoa.h
+++ b/src/backend/cocoa/nvdialog_cocoa.h
@@ -22,10 +22,12 @@
  * IN THE SOFTWARE.
  */
 
+
 #ifndef __nvdialog_cocoa_h__
 #define __nvdialog_cocoa_h__ 1
 
 #include "nvdialog.h"
+#include "nvdialog_string.h"
 #include "nvdialog_typeimpl.h"
 
 /* Shows a dialog box using Cocoa */
@@ -59,7 +61,7 @@ void nvd_about_dialog_set_licence_link_cocoa(NvdAboutDialog *dialog,
 
 void nvd_show_dialog_cocoa(NvdDialogBox *dialog);
 void nvd_show_about_dialog_cocoa(NvdAboutDialog *dialog);
-void nvd_get_file_location_cocoa(NvdFileDialog *dlg, const char **out);
+NvdDynamicString *nvd_get_file_location_cocoa(NvdFileDialog *dlg);
 NvdReply nvd_get_reply_cocoa(NvdQuestionBox *box);
 void nvd_send_notification_cocoa(NvdNotification *notification);
 

--- a/src/backend/cocoa/nvdialog_file_dialog.m
+++ b/src/backend/cocoa/nvdialog_file_dialog.m
@@ -93,8 +93,9 @@ NvdDynamicString *nvd_get_file_location_cocoa(NvdFileDialog *dlg)
 
         dlg->location_was_chosen = resp == NSModalResponseContinue || resp == NSModalResponseOK;
         if (dlg->location_was_chosen) {
+                NSURL *url = [raw URL];
                 nvd_delete_string(dlg->filename);
-                dlg->filename = nvd_string_new(raw.url.absoluteString.UTF8String);
+                dlg->filename = nvd_string_new(url.absoluteString.UTF8String);
         }
 
         [raw release];

--- a/src/backend/cocoa/nvdialog_file_dialog.m
+++ b/src/backend/cocoa/nvdialog_file_dialog.m
@@ -29,6 +29,7 @@
 #include <stdbool.h>
 
 #include "../../nvdialog_assert.h"
+#include "nvdialog_string.h"
 
 /* Contributor's note: NSOpenPanel inherits from NSSavePanel. Unrelated in this context but you may find it useful */
 
@@ -68,7 +69,7 @@ NvdFileDialog *nvd_save_file_dialog_cocoa(const char *title, const char *default
 }
 
 
-void nvd_get_file_location_cocoa(NvdFileDialog *dlg, const char **out)
+NvdDynamicString *nvd_get_file_location_cocoa(NvdFileDialog *dlg)
 {
 	if (dlg->is_dir_dialog) {
         NSOpenPanel *raw = dlg->raw;
@@ -80,7 +81,8 @@ void nvd_get_file_location_cocoa(NvdFileDialog *dlg, const char **out)
         
         if (dlg->location_was_chosen) {
             NSURL *url = [raw URL];
-            *out = strdup(url.absoluteString.UTF8String);
+            nvd_delete_string(dlg->filename);
+            dlg->filename = nvd_string_new(url.absoluteString.UTF8String);
         }
 
         [raw release];
@@ -90,11 +92,14 @@ void nvd_get_file_location_cocoa(NvdFileDialog *dlg, const char **out)
         NSModalResponse resp = [raw runModal];
 
         dlg->location_was_chosen = resp == NSModalResponseContinue || resp == NSModalResponseOK;
-        if (dlg->location_was_chosen)
-            *out = strdup(raw.URL.absoluteString.UTF8String);
+        if (dlg->location_was_chosen) {
+                nvd_delete_string(dlg->filename);
+                dlg->filename = nvd_string_new(raw.url.absoluteString.UTF8String);
+        }
 
         [raw release];
     }
+    return dlg->filename;
 }
 
 void *nvd_open_file_dialog_get_raw_cocoa(NvdFileDialog *dlg)

--- a/src/backend/gtk/nvdialog_file_dialog.c
+++ b/src/backend/gtk/nvdialog_file_dialog.c
@@ -31,6 +31,7 @@
 #include "../../nvdialog_util.h"
 #include "gtk/gtk.h"
 #include "nvdialog_gtk.h"
+#include "nvdialog_string.h"
 
 NvdFileDialog *nvd_open_file_dialog_gtk(const char *title,
                                         const char *file_extensions) {
@@ -103,7 +104,7 @@ NvdFileDialog *nvd_open_folder_dialog_gtk(const char *title,
         return dialog;
 }
 
-static void nvd_get_file_gtk(NvdFileDialog *dialog, const char **savebuf) {
+static NvdDynamicString *nvd_get_file_gtk(NvdFileDialog *dialog) {
         GtkResponseType response = gtk_dialog_run(GTK_DIALOG(dialog->raw));
         char *filename;
         if (response == GTK_RESPONSE_OK || response == GTK_RESPONSE_ACCEPT) {
@@ -123,10 +124,10 @@ static void nvd_get_file_gtk(NvdFileDialog *dialog, const char **savebuf) {
 
         while (gtk_events_pending()) gtk_main_iteration();
 
-        *savebuf = dialog->filename;
+        return dialog->filename;
 }
 
-static void nvd_get_dir_gtk(NvdFileDialog *dialog, const char **savebuf) {
+static NvdDynamicString *nvd_get_dir_gtk(NvdFileDialog *dialog) {
         GtkResponseType response = gtk_dialog_run(GTK_DIALOG(dialog->raw));
         char *filename;
         if (response == GTK_RESPONSE_OK || response == GTK_RESPONSE_ACCEPT) {
@@ -135,7 +136,7 @@ static void nvd_get_dir_gtk(NvdFileDialog *dialog, const char **savebuf) {
                 dialog->location_was_chosen = true;
                 gtk_widget_destroy(dialog->raw);
                 if (filename) {
-                        dialog->filename = strdup(filename);
+                        dialog->filename = nvd_string_new(filename);
                         g_free(filename);
                 }
         } else {
@@ -146,7 +147,7 @@ static void nvd_get_dir_gtk(NvdFileDialog *dialog, const char **savebuf) {
 
         while (gtk_events_pending()) gtk_main_iteration();
 
-        *savebuf = dialog->filename;
+        return dialog->filename;
 }
 
 void *nvd_open_file_dialog_get_raw_gtk(NvdFileDialog *dlg) {
@@ -154,11 +155,8 @@ void *nvd_open_file_dialog_get_raw_gtk(NvdFileDialog *dlg) {
         return dlg->raw;
 }
 
-void nvd_get_file_location_gtk(NvdFileDialog *dialog, const char **savebuf) {
+NvdDynamicString *nvd_get_file_location_gtk(NvdFileDialog *dialog) {
         if (dialog->is_dir_dialog) {
-                nvd_get_dir_gtk(dialog, savebuf);
-                return;
-        }
-
-        nvd_get_file_gtk(dialog, savebuf);
+                return nvd_get_dir_gtk(dialog);
+        } else  return nvd_get_file_gtk(dialog);
 }

--- a/src/backend/gtk/nvdialog_file_dialog.c
+++ b/src/backend/gtk/nvdialog_file_dialog.c
@@ -113,7 +113,8 @@ static NvdDynamicString *nvd_get_file_gtk(NvdFileDialog *dialog) {
                 dialog->location_was_chosen = true;
                 gtk_widget_destroy(dialog->raw);
                 if (filename) {
-                        dialog->filename = strdup(filename);
+                        nvd_delete_string(dialog->filename);
+                        dialog->filename = nvd_string_new(filename);
                         g_free(filename);
                 }
         } else {

--- a/src/backend/gtk/nvdialog_gtk.h
+++ b/src/backend/gtk/nvdialog_gtk.h
@@ -29,6 +29,7 @@
 
 #include "../nvdialog_util.h"
 #include "nvdialog.h"
+#include "nvdialog_string.h"
 #include "nvdialog_typeimpl.h"
 
 /* Shows a simple dialog box using Gtk3. */
@@ -82,7 +83,7 @@ void nvd_about_dialog_set_license_link_gtk(NvdAboutDialog *dialog,
  * Gets the full path of a file, and returns the path
  * inside the 'save' nested pointer passed.
  */
-void nvd_get_file_location_gtk(NvdFileDialog *dialog, const char **savebuf);
+NvdDynamicString *nvd_get_file_location_gtk(NvdFileDialog *dialog);
 
 /*
  * Notification using Gtk3 backend.

--- a/src/backend/sandbox/nvdialog_file_dialog.c
+++ b/src/backend/sandbox/nvdialog_file_dialog.c
@@ -25,10 +25,10 @@
 #include "dialogs/nvdialog_file_dialog.h"
 
 #include <stdlib.h>
-#include <string.h>
 
 #include "../../nvdialog_assert.h"
 #include "nvdialog_sbx.h"
+#include "nvdialog_string.h"
 
 NvdFileDialog *nvd_open_file_dialog_sbx(const char *title,
                                         const char *file_extensions) {
@@ -60,7 +60,7 @@ void *nvd_open_file_dialog_get_raw_sbx(NvdFileDialog *dlg) {
         return dlg->raw;
 }
 
-void nvd_get_file_location_sbx(NvdFileDialog *dialog, const char **savebuf) {
+NvdDynamicString *nvd_get_file_location_sbx(NvdFileDialog *dialog) {
         GtkResponseType response =
                 gtk_native_dialog_run(GTK_NATIVE_DIALOG(dialog->raw));
         char *filename;
@@ -70,7 +70,8 @@ void nvd_get_file_location_sbx(NvdFileDialog *dialog, const char **savebuf) {
                 dialog->location_was_chosen = true;
                 gtk_widget_destroy(dialog->raw);
                 if (filename) {
-                        dialog->filename = strdup(filename);
+                        nvd_delete_string(dialog->filename);
+                        dialog->filename = nvd_string_new(filename);
                         g_free(filename);
                 }
         } else {
@@ -81,5 +82,5 @@ void nvd_get_file_location_sbx(NvdFileDialog *dialog, const char **savebuf) {
 
         while (gtk_events_pending()) gtk_main_iteration();
 
-        *savebuf = dialog->filename;
+        return dialog->filename;
 }

--- a/src/backend/sandbox/nvdialog_sbx.h
+++ b/src/backend/sandbox/nvdialog_sbx.h
@@ -28,6 +28,7 @@
 #include <gtk/gtk.h>
 
 #include "nvdialog.h"
+#include "nvdialog_string.h"
 #include "nvdialog_typeimpl.h"
 
 /* Shows a simple dialog box using Gtk3 (Sandbox version). */
@@ -80,7 +81,7 @@ void nvd_about_dialog_set_license_link_sbx(NvdAboutDialog *dialog,
  * Gets the full path of a file, and returns the path
  * inside the 'save' nested pointer passed.
  */
-void nvd_get_file_location_sbx(NvdFileDialog *dialog, const char **savebuf);
+NvdDynamicString *nvd_get_file_location_sbx(NvdFileDialog *dialog);
 
 /*
  * Notification using Gtk3 backend.

--- a/src/backend/win32/nvdialog_win32.h
+++ b/src/backend/win32/nvdialog_win32.h
@@ -66,7 +66,7 @@ void nvd_show_about_dialog_win32(NvdAboutDialog *dialog);
 void nvd_about_dialog_set_version_win32(NvdAboutDialog *dialog,
                                         const char *version);
 
-NvdDynamicString nvd_get_file_location_win32(NvdFileDialog *dialog);
+NvdDynamicString *nvd_get_file_location_win32(NvdFileDialog *dialog);
 
 NvdNotification *nvd_notification_win32(const char *title, const char *msg,
                                         NvdNotifyType type);

--- a/src/backend/win32/nvdialog_win32.h
+++ b/src/backend/win32/nvdialog_win32.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "nvdialog_string.h"
 #ifndef __nvdialog_win32_h__
 #define __nvdialog_win32_h__ 1
 
@@ -65,7 +66,7 @@ void nvd_show_about_dialog_win32(NvdAboutDialog *dialog);
 void nvd_about_dialog_set_version_win32(NvdAboutDialog *dialog,
                                         const char *version);
 
-void nvd_get_file_location_win32(NvdFileDialog *dialog, const char **savebuf);
+NvdDynamicString nvd_get_file_location_win32(NvdFileDialog *dialog);
 
 NvdNotification *nvd_notification_win32(const char *title, const char *msg,
                                         NvdNotifyType type);

--- a/src/impl/nvdialog_typeimpl.h
+++ b/src/impl/nvdialog_typeimpl.h
@@ -96,4 +96,10 @@ struct _NvdImage {
         int width, height;
 };
 
+struct _NvdDynamicString {
+    size_t len;
+    size_t capacity;
+    char *buffer;
+};
+
 #endif /* __nvdialog_typeimpl_h */

--- a/src/impl/nvdialog_typeimpl.h
+++ b/src/impl/nvdialog_typeimpl.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "nvdialog_string.h"
 #ifndef __nvdialog_typeimpl_h
 #define __nvdialog_typeimpl_h (1)
 
@@ -58,8 +59,9 @@ struct _NvdAboutDialog {
 
 struct _NvdFileDialog {
         void* raw;
-        const char* title;
-        const char *filename, *file_extensions;
+        const char *title;
+        const char *file_extensions;
+        NvdDynamicString *filename;
         bool location_was_chosen, is_save_dialog, is_dir_dialog;
 };
 

--- a/src/nvdialog_error.c
+++ b/src/nvdialog_error.c
@@ -92,12 +92,6 @@ void nvd_error_message(const char *fmt, ...) {
         fflush(stderr);
 }
 
-void NVD_DEPRECATED(
-        "This function has been deprecated in favor of nvd_error_message. "
-        "Please "
-        "use that instead of this function.") nvd_print(const char *msg) {
-        fprintf(stderr, "%s", msg);
-}
 
 void nvd_out_of_memory() {
         nvd_error_message("%s%d%s%s", "Host machine out of memory: (errno ",

--- a/src/nvdialog_error.c
+++ b/src/nvdialog_error.c
@@ -31,6 +31,7 @@
 #include <string.h>
 
 #include "nvdialog_macros.h"
+#include "nvdialog_string.h"
 
 NVD_THREAD_LOCAL(NvdError ___error) = NVD_NO_ERROR;
 
@@ -54,51 +55,28 @@ NVD_INTERNAL_FUNCTION NVD_FORCE_INLINE void nvd_set_error(NvdError error) {
 #endif /* __cplusplus */
 NVD_FORCE_INLINE NvdError nvd_get_error(void) { return ___error; }
 
-const char *nvd_stringify_error(NvdError err) {
-        static char *error = NULL;
-        switch (err) {
-                case NVD_NO_ERROR:
-                        error = "No error";
-                        break;
-                case NVD_NO_DISPLAY:
-                        error = "No display found (Is X.org or a Wayland "
-                                "compositor "
-                                "running?)";
-                        break;
-                case NVD_BACKEND_FAILURE:
-                        error = "Backend initialization was unsuccesful "
-                                "(Invalid parameters?).";
-                        break;
-                case NVD_INVALID_PARAM:
-                        error = "Invalid parameter passed.";
-                        break;
-                case NVD_NOT_INITIALIZED:
-                        error = "The library wasn't initialized.";
-                        break;
-                case NVD_ALREADY_INITIALIZED:
-                        error = "The library has been already initialized.";
-                        break;
-                case NVD_STRING_EMPTY:
-                        error = "Passed empty string as a parameter.";
-                        break;
-                case NVD_FILE_INACCESSIBLE:
-                        error = "Attempted to read an inaccessible file.";
-                        break;
-                case NVD_BACKEND_INVALID:
-                        error = "Backend library is not matching NvDialog.";
-                        break;
-                case NVD_OUT_OF_MEMORY:
-                        error = "No memory left on the host machine.";
-                        break;
-                case NVD_INTERNAL_ERROR:
-                        error = "Internal library error - Open an issue on "
-                                "GitHub.";
-                        break;
-                default:
-                        nvd_set_error(NVD_INVALID_PARAM);
-                        return NULL;
+NvdDynamicString *nvd_stringify_error(NvdError err) {
+        static const char *messages[] = {
+                [NVD_NO_ERROR] = "No error",
+                [NVD_NO_DISPLAY] = "No display/desktop detected, make sure X11/Wayland is up and running.",
+                [NVD_BACKEND_FAILURE] = "Failed to initialize one of the backends.",
+                [NVD_INVALID_PARAM] = "Invalid parameter passed to a function.",
+                [NVD_NOT_INITIALIZED] = "The library wasn't initialized.",
+                [NVD_ALREADY_INITIALIZED] = "The library has already been initialized.",
+                [NVD_STRING_EMPTY] = "Passed an empty string as a parameter.",
+                [NVD_FILE_INACCESSIBLE] = "Attempted to read an inaccessible file.",
+                [NVD_BACKEND_INVALID] = "Invalid or corrupt backend, make sure your system is up to date.",
+                [NVD_OUT_OF_MEMORY] = "No memory left on the host machine.",
+                [NVD_INTERNAL_ERROR] = "Internal or unexpected library error - Open an issue on GitHub."
+        };
+
+        if (err >= sizeof(messages)/sizeof(*messages) || !messages[err]) {
+                nvd_set_error(NVD_INVALID_PARAM);
+                return NULL;
         }
-        return error;
+
+        NvdDynamicString *str = nvd_string_new(messages[err]);
+        return str;
 }
 
 void nvd_error_message(const char *fmt, ...) {

--- a/src/nvdialog_init.c
+++ b/src/nvdialog_init.c
@@ -102,8 +102,7 @@ int nvd_init_cocoa(NvdBackendMask *mask) {
         mask->open_file_dialog = nvd_open_file_dialog_cocoa;
         mask->save_file_dialog = nvd_save_file_dialog_cocoa;
         mask->open_folder_dialog = nvd_open_folder_dialog_cocoa;
-        mask->get_file_location =
-                (void (*)(NvdFileDialog *, char **))nvd_get_file_location_cocoa;
+        mask->get_file_location = nvd_get_file_location_cocoa;
         mask->notification = nvd_notification_cocoa;
         mask->send_notification = nvd_send_notification_cocoa;
         mask->add_notification_action = nvd_add_notification_action_cocoa;

--- a/src/nvdialog_init.c
+++ b/src/nvdialog_init.c
@@ -58,9 +58,7 @@ int nvd_init_gtk3(NvdBackendMask *mask) {
         mask->open_file_dialog = nvd_open_file_dialog_gtk;
         mask->save_file_dialog = nvd_save_file_dialog_gtk;
         mask->open_folder_dialog = nvd_open_folder_dialog_gtk;
-        mask->get_file_location = (void (*)(NvdFileDialog *, char **))
-                nvd_get_file_location_gtk;  // Cast necessary because I am an
-                                            // idiot
+        mask->get_file_location = nvd_get_file_location_gtk;
         mask->notification = nvd_notification_gtk;
         mask->send_notification = nvd_send_notification_gtk;
         mask->add_notification_action = nvd_add_notification_action_gtk;
@@ -82,8 +80,7 @@ int nvd_init_win32(NvdBackendMask *mask) {
         mask->open_file_dialog = nvd_open_file_dialog_win32;
         mask->save_file_dialog = nvd_save_file_dialog_win32;
         mask->open_folder_dialog = nvd_open_folder_dialog_win32;
-        mask->get_file_location =
-                (void (*)(NvdFileDialog *, char **))nvd_get_file_location_win32;
+        mask->get_file_location = nvd_get_file_location_win32;
         mask->notification = nvd_notification_win32;
         mask->send_notification = nvd_send_notification_win32;
         mask->add_notification_action = nvd_add_notification_action_win32;

--- a/src/nvdialog_init.h
+++ b/src/nvdialog_init.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "nvdialog_string.h"
 #ifndef __nvdialog_init_h__
 #define __nvdialog_init_h__ 1
 
@@ -63,7 +64,7 @@ typedef struct _NvdBackendMask {
         NvdFileDialog *(*open_file_dialog)(const char *, const char *);
         NvdFileDialog *(*save_file_dialog)(const char *, const char *);
         NvdFileDialog *(*open_folder_dialog)(const char *, const char *);
-        void (*get_file_location)(NvdFileDialog *, char **);
+        NvdDynamicString *(*get_file_location)(NvdFileDialog *);
 
         NvdNotification *(*notification)(const char *, const char *,
                                          NvdNotifyType);

--- a/src/nvdialog_main.c
+++ b/src/nvdialog_main.c
@@ -22,7 +22,8 @@
  * IN THE SOFTWARE.
  */
 
-#define _CRT_SECURE_NO_WARNINGS 1
+ #define _CRT_SECURE_NO_WARNINGS 1
+ #include "nvdialog_string.h"
 #include "dialogs/nvdialog_dialog_box.h"
 #include "dialogs/nvdialog_file_dialog.h"
 #include "nvdialog.h"
@@ -36,7 +37,6 @@
 #elif NVD_USE_COCOA
 #include "backend/cocoa/nvdialog_cocoa.h"
 #else
-#include "backend/gtk/nvdialog_gtk.h"
 #endif /* NVD_USE_GTK4 */
 #else
 #include "backend/win32/nvdialog_win32.h"
@@ -230,10 +230,9 @@ NvdFileDialog *nvd_open_folder_dialog_new(const char *title,
                                   default_filename);
 }
 
-void nvd_get_file_location(NvdFileDialog *dialog, const char **savebuf) {
+NvdDynamicString *nvd_get_file_location(NvdFileDialog *dialog) {
         NVD_ASSERT(dialog != NULL);
-        NVD_ASSERT(savebuf != NULL);
-        NVD_TRY_CALL(mask.get_file_location, dialog, (char **)savebuf);
+        return NVD_CHECK_FUNCTION(mask.get_file_location, dialog);
 }
 
 NvdNotification *nvd_notification_new(const char *title, const char *msg,

--- a/src/nvdialog_string.c
+++ b/src/nvdialog_string.c
@@ -1,0 +1,115 @@
+/*
+ *  The MIT License (MIT)
+ *
+ *  Copyright (c) 2025 Aggelos Tselios
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "nvdialog_string.h"
+#include "nvdialog_assert.h"
+#include "nvdialog_util.h"
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* The default capacity of a string. This doesn't affect anything other than how often we will have to reallocate. */
+#define NVD_DEFAULT_STRING_CAPACITY (32)
+
+struct _NvdDynamicString {
+    size_t len;
+    size_t capacity;
+    char *buffer;
+};
+
+NvdDynamicString *nvd_string_new(const char *data) {
+    NvdDynamicString *obj = malloc(sizeof(NvdDynamicString));
+    NVD_RETURN_IF_NULL(obj);
+    if (data) {
+        size_t datalen = strlen(data);
+        obj->buffer = malloc(datalen + 1);
+        obj->len = datalen;
+        obj->capacity = (datalen + 1);
+        memcpy(obj->buffer, data, datalen);
+        obj->buffer[datalen] = '\0';
+    } else {
+        obj->buffer = calloc(1, NVD_DEFAULT_STRING_CAPACITY);
+        obj->capacity = NVD_DEFAULT_STRING_CAPACITY;
+        obj->len = 0;
+    }
+
+    return obj;
+}
+
+void nvd_string_set_data(NvdDynamicString *string, const char *data) {
+    NVD_ASSERT_FATAL(string != NULL);
+    NVD_ASSERT_FATAL(data != NULL);
+
+    size_t len = strlen(data);
+
+    if ((len + 1) > string->capacity) {
+        size_t new_capacity = string->capacity + len + NVD_DEFAULT_STRING_CAPACITY;
+        string->buffer = realloc(string->buffer, new_capacity);
+        string->capacity = new_capacity;
+        string->len = len;
+    }
+    memcpy(string->buffer, data, len);
+    string->buffer[len] = '\0';
+}
+
+NvdDynamicString *nvd_duplicate_string(NvdDynamicString *other) {
+    NVD_ASSERT_FATAL(other != NULL);
+
+    NvdDynamicString *string = malloc(sizeof(NvdDynamicString));
+    string->buffer = malloc(other->capacity);
+    string->capacity = other->capacity;
+    string->len = other->len;
+
+    memcpy(string->buffer, other->buffer, string->len + 1);
+    return string;
+}
+
+const char *nvd_string_to_cstr(NvdDynamicString *string) {
+    NVD_ASSERT_FATAL(string != NULL);
+    /* The implementation only uses C-approved `char`s and NULL-terminates buffer for ease of use, so we can just return this. */
+    return string->buffer;
+}
+
+void nvd_string_reserve(NvdDynamicString *string, size_t bytes) {
+    if (bytes > string->capacity) {
+        string->buffer = realloc(string->buffer, bytes);
+        string->capacity = bytes;
+    }
+}
+
+size_t nvd_strlen(NvdDynamicString *string) {
+    return string->len;
+}
+
+void nvd_string_clear(NvdDynamicString *string) {
+    nvd_zero_memory(string->buffer, string->capacity);
+    string->len = 0;
+}
+
+void nvd_delete_string(NvdDynamicString *string) {
+    if (!string) return;
+
+    free(string->buffer);
+    free(string);
+}

--- a/src/nvdialog_string.c
+++ b/src/nvdialog_string.c
@@ -23,6 +23,7 @@
  */
 
 #include "nvdialog_string.h"
+#include "nvdialog_typeimpl.h"
 #include "nvdialog_assert.h"
 #include "nvdialog_util.h"
 #include <stddef.h>
@@ -31,12 +32,6 @@
 
 /* The default capacity of a string. This doesn't affect anything other than how often we will have to reallocate. */
 #define NVD_DEFAULT_STRING_CAPACITY (32)
-
-struct _NvdDynamicString {
-    size_t len;
-    size_t capacity;
-    char *buffer;
-};
 
 NvdDynamicString *nvd_string_new(const char *data) {
     NvdDynamicString *obj = malloc(sizeof(NvdDynamicString));
@@ -62,12 +57,14 @@ void nvd_string_set_data(NvdDynamicString *string, const char *data) {
     NVD_ASSERT_FATAL(data != NULL);
 
     size_t len = strlen(data);
+    string->len = len;
+    /* Data may persist beyond len otherwise. */
+    nvd_zero_memory(string->buffer, string->capacity);
 
     if ((len + 1) > string->capacity) {
         size_t new_capacity = string->capacity + len + NVD_DEFAULT_STRING_CAPACITY;
         string->buffer = realloc(string->buffer, new_capacity);
-        string->capacity = new_capacity;
-        string->len = len;
+        string->capacity = new_capacity;    
     }
     memcpy(string->buffer, data, len);
     string->buffer[len] = '\0';

--- a/src/nvdialog_util.c
+++ b/src/nvdialog_util.c
@@ -44,13 +44,7 @@ static inline bool nvd_file_exists(const char* path) {
         return (access(path, 0) == 0);
 }
 
-/**
- * @brief Writes @ref size bytes to @ref ptr to ensure proper initialization.
- * @param ptr A pointer to the data structure where the NULL bytes will be
- * written.
- * @param size The amount of NULL bytes to write before stopping.
- */
-static void nvd_zero_memory(void* ptr, size_t size) { memset(ptr, 0, size); }
+void nvd_zero_memory(void* ptr, size_t size) { memset(ptr, 0, size); }
 
 #if defined(__linux__) || defined(__linux) || defined(__gnu_linux__)
 static void nvd_read_os_release(NvdDistroInfo* info) {

--- a/src/nvdialog_util.c
+++ b/src/nvdialog_util.c
@@ -32,6 +32,7 @@
 
 #include "nvdialog_assert.h"
 #include "nvdialog_macros.h"
+#include "nvdialog_string.h"
 
 #ifdef _WIN32
 #include <io.h>
@@ -162,20 +163,19 @@ NVD_INTERNAL_FUNCTION NvdDistroInfo nvd_get_distro_branch() {
         return info;
 }
 
-NVD_INTERNAL_FUNCTION char* nvd_get_libnotify_path() {
-        size_t max_pathlen = strlen("/usr/lib/x86_64-linux-gnu/libnotify.so");
-        char* buffer = malloc(max_pathlen + 16);  // 16 byte padding
+NVD_INTERNAL_FUNCTION const NvdDynamicString *nvd_get_libnotify_path() {
+        NvdDynamicString *str = nvd_string_new(NULL);
 
         NvdDistroInfo info = nvd_get_distro_branch();
 
         /* TODO: Please add more distribution checks here.*/
         if (strcmp(info.name, "Debian") == 0)
-                strcpy(buffer, "/usr/lib/x86_64-linux-gnu/libnotify.so");
+                nvd_string_set_data(str, "/usr/lib/x86_64-linux-gnu/libnotify.so");
         else if (strcmp(info.name, "Arch") == 0)
-                strcpy(buffer, "/usr/lib/libnotify.so");
+                nvd_string_set_data(str, "/usr/lib/libnotify.so");
         else
-                strcpy(buffer, "/usr/lib/libnotify.so");
+                nvd_string_set_data(str, "/usr/lib/libnotify.so");
 
-        return buffer;
+        return str;
 }
 #endif /* __linux__ */

--- a/src/nvdialog_util.h
+++ b/src/nvdialog_util.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "nvdialog_string.h"
 #ifndef __nvdialog_util_h__
 #define __nvdialog_util_h__ (1)
 
@@ -124,7 +125,7 @@ NvdDistroInfo nvd_get_distro_branch();
  *
  * @return The path to libnotify on each platform if succesfull, otherwise NULL.
  */
-char* nvd_get_libnotify_path();
+const NvdDynamicString *nvd_get_libnotify_path();
 
 /**
  * @brief Returns the path the library is using to find `libnotify`.

--- a/src/nvdialog_util.h
+++ b/src/nvdialog_util.h
@@ -49,6 +49,14 @@ typedef struct _NvdDistroInfo {
 } NvdDistroInfo;
 
 /**
+ * @brief Writes @ref size bytes to @ref ptr to ensure proper initialization.
+ * @param ptr A pointer to the data structure where the NULL bytes will be
+ * written.
+ * @param size The amount of NULL bytes to write before stopping.
+ */
+void nvd_zero_memory(void* ptr, size_t size);
+
+/**
  * @brief An identifier to match a new process ID spawned by @ref
  * nvd_create_process
  * @details Similar to the `pid_t` type (And similarly defined), this type


### PR DESCRIPTION
For years now, due to the "barebones" nature of C, it was pretty hard to return strings from the library to the user/developer. We had to rely on unsafe or simply questionable designs like this:

https://github.com/tseli0s/nvdialog/blob/9b4253a588e3a7cc702771e7881f2ebf1d08af60/src/nvdialog_error.c#L57-L102

Or this:

https://github.com/tseli0s/nvdialog/blob/9b4253a588e3a7cc702771e7881f2ebf1d08af60/src/backend/gtk/nvdialog_file_dialog.c#L124-L126

And it gets worse as you dig through the source code. 

The aim of this pull request is to introduce a sorely desired redesign and a new unified string type that works across all backends, all languages, all setups and most importantly is heap allocated. This was thought of before, but now, with the new arrival of an (spoiler) input box, this is very much needed. It will also make interacting with other libraries much easier. Worth mentioning that while it's impossible to do implicit casting between the new `NvdDynamicString` type and a traditional `const char*` string, the new API is written with as much interoperability as possible in mind.

Related (or simply what could've been prevented): #53, #56.
