### PR TITLE
Fix `make install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ install:
 	mkdir -p $(INCDIR)
 	mkdir -p $(DIALOGDIR)
 	cp $(TARGET) $(LIBDIR)/
-	cp include/nvdialog_*.h $(INCDIR)/
+	cp include/nvdialog*.h $(INCDIR)/
 	cp include/dialogs/nvdialog_*.h $(DIALOGDIR)/
 
 uninstall:


### PR DESCRIPTION
Running `make install` previously didn't include the `nvdialog.h` file due to the use of `nvdialog_*.h` excluding it.
Removing the `_` fixes the issue.