### PR TITLE
Wide string support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ option(NVD_BUILD_STATIC "Build NvDialog as a static library." ON)
 option(NVD_GENERATE_DOCS "Generate documentation for NvDialog. Requires doxygen to be installed" OFF) # Off by default because doxygen may not be available
 option(NVD_USE_GNUSTEP "Use the GNUstep+Cocoa backend on generation. Only intended for testing." OFF)
 option(NVD_IMAGE_SUPPORT "Add support for images through nvdialog, only disable this if you're building nvdialog statically!" ON)
-
+ 
 set(CMAKE_C_STANDARD 11)
 add_compile_definitions(NVDIALOG_MAXBUF=4096 NVD_EXPORT_SYMBOLS)
 if (NVD_IMAGE_SUPPORT)
@@ -125,7 +125,7 @@ endif()
 
 if(NVD_BUILD_STATIC)
     add_library(nvdialog STATIC ${NVD_SOURCES})
-    add_compile_definitions(NVD_STATIC_LINKAGE)
+    target_compile_definitions(nvdialog PUBLIC NVD_STATIC_LINKAGE)
 else()
     add_library(nvdialog SHARED ${NVD_SOURCES})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ else()
     add_library(nvdialog SHARED ${NVD_SOURCES})
 endif()
 
-target_include_directories(nvdialog PRIVATE ${CMAKE_SOURCE_DIR}/src/impl/ ${CMAKE_SOURCE_DIR}/vendor)
+target_include_directories(nvdialog PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/impl/ ${CMAKE_CURRENT_SOURCE_DIR}/vendor)
 
 if(APPLE)
     target_link_libraries(nvdialog
@@ -159,7 +159,7 @@ elseif(UNIX AND NOT APPLE)
 endif()
 
 set_target_properties(nvdialog PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION 3)
-target_include_directories(nvdialog PRIVATE include/)
+target_include_directories(nvdialog PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 if (NVD_GENERATE_DOCS)
     set(NVD_DOXYFILE ${CMAKE_SOURCE_DIR}/Doxyfile)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,6 @@ if (NVD_IMAGE_SUPPORT)
     add_compile_definitions(_NVD_SUPPORT_IMAGES)
 endif()
 
-include_directories(${CMAKE_SOURCE_DIR}/src/impl/ ${CMAKE_SOURCE_DIR}/vendor)
-
 if (NVD_USE_GTK4)
     message(WARNING "**IMPORTANT** The build system detected that you are trying to build this library with the Gtk4/libadwaita backend. This backend is being deprecated as of version v0.10. For future-proofness, resort to the default gtk backend instead. See PR #59 on the repository for further details.")
     message("-- If you are building for Windows/macOS, you can ignore the warning above.")
@@ -131,6 +129,8 @@ if(NVD_BUILD_STATIC)
 else()
     add_library(nvdialog SHARED ${NVD_SOURCES})
 endif()
+
+target_include_directories(nvdialog ${CMAKE_SOURCE_DIR}/src/impl/ ${CMAKE_SOURCE_DIR}/vendor)
 
 if(APPLE)
     target_link_libraries(nvdialog

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ set(NVD_COMMON_SOURCES
     src/nvdialog_version.c
     src/nvdialog_init.c
     src/nvdialog_string.c
+    src/nvdialog_wide_string.c
     src/nvdialog_main.c)
 
 if(WIN32 OR CROSS_COMPILE_FOR_WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ else()
     add_library(nvdialog SHARED ${NVD_SOURCES})
 endif()
 
-target_include_directories(nvdialog ${CMAKE_SOURCE_DIR}/src/impl/ ${CMAKE_SOURCE_DIR}/vendor)
+target_include_directories(nvdialog PRIVATE ${CMAKE_SOURCE_DIR}/src/impl/ ${CMAKE_SOURCE_DIR}/vendor)
 
 if(APPLE)
     target_link_libraries(nvdialog

--- a/include/nvdialog.h
+++ b/include/nvdialog.h
@@ -87,37 +87,6 @@ extern "C" {
                 (NvdVersion) x.patch = NVDIALOG_VERSION_PATCH; \
         }
 
-#if !defined(NVD_API_EXPORT) && !defined(NVD_API_IMPORT) && !defined(NVD_API)
-
-#if defined(_WIN32) || defined(WIN32)
-#if defined(__clang__) || defined(__GNUC__)
-#define NVD_API_EXPORT __attribute__((dllexport))
-#else /* __clang__ */
-#define NVD_API_EXPORT __declspec(dllexport)
-#endif /* NVD_API */
-#else  /* _WIN32 */
-#define NVD_API_EXPORT
-#endif /* _WIN32 */
-
-#if defined(_WIN32) || defined(WIN32)
-#if defined(__clang__) || defined(__GNUC__)
-#define NVD_API_IMPORT __attribute__((dllimport))
-#else /* __clang__ */
-#define NVD_API_IMPORT __declspec(dllimport)
-#endif /* NVD_API */
-#else  /* _WIN32 */
-#define NVD_API_IMPORT
-#endif /* _WIN32 */
-
-#if defined(NVD_EXPORT_SYMBOLS)
-#define NVD_API NVD_API_EXPORT
-#else
-#define NVD_API NVD_API_IMPORT
-#endif /* DLLEXPORT */
-
-#endif /* !defined(NVD_API_EXPORT) && !defined(NVD_API_IMPORT) && \
-          !defined(NVD_API) */
-
 #if !defined(_WIN32) || !defined(WIN32)
 
 #if __STDC_VERSION__ >= 201112L
@@ -137,6 +106,7 @@ extern "C" {
 #define NVD_THREAD_LOCAL(var) static var
 #endif /* _WIN32 */
 
+#include "nvdialog_platform.h"
 #include "nvdialog_capab.h"
 #include "nvdialog_core.h"
 #include "nvdialog_dialog.h"

--- a/include/nvdialog_platform.h
+++ b/include/nvdialog_platform.h
@@ -25,6 +25,8 @@
 #ifndef __nvdialog_platform_h__
 #define __nvdialog_platform_h__ (1)
 
+#if !defined(NVD_API_EXPORT) && !defined(NVD_API_IMPORT) && !defined(NVD_API) && !defined(NVD_STATIC_LINKAGE)
+
 #if defined(_WIN32) || defined(WIN32)
 #if defined(__clang__) || defined(__GNUC__)
 #define NVD_API_EXPORT __attribute__((dllexport))
@@ -50,5 +52,12 @@
 #else
 #define NVD_API NVD_API_IMPORT
 #endif /* DLLEXPORT */
+
+#endif /* !defined(NVD_API_EXPORT) && !defined(NVD_API_IMPORT) && \
+          !defined(NVD_API) && !defined(NVD_STATIC_LINKAGE) */
+
+#if !defined(NVD_API)
+#define NVD_API
+#endif /* !defined(NVD_API) */
 
 #endif /* __nvdialog_platform_h__ */

--- a/include/nvdialog_widestr.h
+++ b/include/nvdialog_widestr.h
@@ -1,0 +1,99 @@
+/*
+ *  The MIT License (MIT)
+ *
+ *  Copyright (c) 2026 Aggelos Tselios
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#ifndef __nvdialog_widestr_h__
+#define __nvdialog_widestr_h__ 1
+
+#include <limits.h>
+#include <wchar.h>
+
+#include "nvdialog_platform.h"
+#include "nvdialog_string.h"
+
+#define NVD_WCHAR_BITS (sizeof(wchar_t) * CHAR_BIT)
+
+/**
+ * @brief A wide character based string.
+ * @details Wide characters are character representations that use more than one
+ * byte per character, allowing support for large character sets such as
+ * Unicode.
+ * @note Windows uses 16 bit characters as wide characters, whereas most other
+ * operating systems use 32 bits. See @ref NVD_WCHAR_BITS to know how many bits
+ * does each character use.
+ * @sa NvdDynamicString (the regular C string equivalent)
+ * @since x.x.x (TODO)
+ * @ingroup WideString
+ */
+typedef struct _NvdWideString NvdWideString;
+
+/**
+ * @brief Allocates an @ref NvdWideString out of a wide character buffer.
+ * @since x.x.x (TODO)
+ * @return An @ref NvdWideString on success, or NULL on failure; Call @ref
+ * nvd_get_error for details.
+ * @ingroup WideString
+ */
+NVD_API NvdWideString *nvd_wide_string_new(const wchar_t *buffer);
+
+/**
+ * @brief Tries to cast a wide string to a regular string, if possible.
+ * @warning There's no guarantee that this function will succeed. You should
+ * check the return value and validate the string's data before using them.
+ * @since x.x.x (TODO)
+ * @return An @ref NvdDynamicString with C-style contents on success, or NULL on
+ * failure; Call @ref nvd_get_error for details.
+ * @ingroup WideString
+ */
+NVD_API NvdDynamicString *nvd_wide_to_c_str(NvdWideString *str);
+
+/**
+ * @brief Returns the length of the given `NvdWideString`.
+ * @param string The string whose length will be measured. Must not be `NULL`.
+ * @returns The number of characters in the string, excluding the
+ * null-terminator.
+ * @since x.x.x (TODO)
+ * @ingroup WideString
+ */
+NVD_API size_t nvd_wide_strlen(NvdWideString *string);
+
+/**
+ * @brief Returns the internal wide character buffer of the given @ref
+ * NvdWideString.
+ * @since x.x.x (TODO)
+ * @ingroup WideString
+ * @return The internal wide character buffer of the given @ref NvdWideString or
+ * NULL on failure.
+ */
+NVD_API wchar_t *nvd_get_internal_wide_string(NvdWideString *str);
+
+/**
+ * @brief Deallocates the @ref NvdWideString given.
+ * @since x.x.x (TODO)
+ * @ingroup WideString
+ */
+NVD_API void nvd_delete_wide_string(NvdWideString *str);
+
+#endif /* __nvdialog_widestr_h__ */

--- a/src/impl/nvdialog_typeimpl.h
+++ b/src/impl/nvdialog_typeimpl.h
@@ -24,7 +24,6 @@
 
 #pragma once
 
-#include "nvdialog_string.h"
 #ifndef __nvdialog_typeimpl_h
 #define __nvdialog_typeimpl_h (1)
 
@@ -33,6 +32,20 @@
 #include <stdbool.h>
 
 #include "nvdialog.h"
+#include "nvdialog_string.h"
+#include "nvdialog_widestr.h"
+
+typedef enum _NvdWideCharWidth {
+	NVD_WCHAR_WIDTH_8, /* That should never be used, but keep it around for
+			      bug checking */
+	NVD_WCHAR_WIDTH_16,
+	NVD_WCHAR_WIDTH_24, /* unrealistic, but some platforms have this
+			       apparently. Maybe for future expansion? */
+	NVD_WCHAR_WIDTH_32,
+	NVD_WCHAR_WIDTH_64, /* That probably doesn't even exist. Maybe in 100
+			       years it will, or when aliens come around and
+			       need to type their language. */
+} NvdWideCharWidth;
 
 struct _NvdDialogBox {
         void* window_handle;
@@ -100,6 +113,12 @@ struct _NvdDynamicString {
     size_t len;
     size_t capacity;
     char *buffer;
+};
+
+struct _NvdWideString {
+	size_t len;
+	size_t mem_usage;
+	wchar_t* buffer;
 };
 
 #endif /* __nvdialog_typeimpl_h */

--- a/src/nvdialog_wide_string.c
+++ b/src/nvdialog_wide_string.c
@@ -1,0 +1,97 @@
+/*
+ *  The MIT License (MIT)
+ *
+ *  Copyright (c) 2026 Aggelos Tselios
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include <stdlib.h>
+#include <wchar.h>
+
+#include "impl/nvdialog_typeimpl.h"
+#include "nvdialog_assert.h"
+#include "nvdialog_error.h"
+#include "nvdialog_string.h"
+#include "nvdialog_util.h"
+#include "nvdialog_widestr.h"
+
+#define NVD_DEFAULT_WSTRING_LEN (48)
+
+/* Apparently things are different between Unix and Windows so we have to do
+ * this by hand for some platforms. Might as well do it for all of them. */
+static wchar_t *nvd_strdup_wide(const wchar_t *str) {
+	if (!str) return NULL;
+	size_t len = wcslen(str);
+	wchar_t *buffer = nvd_malloc((len + 1) * sizeof(wchar_t));
+
+	memcpy(buffer, str, (len + 1) * sizeof(wchar_t));
+	return buffer;
+}
+
+NvdWideString *nvd_wide_string_new(const wchar_t *buffer) {
+	NvdWideString *string = nvd_calloc(1, sizeof(NvdWideString));
+	NVD_ASSERT(string != NULL);
+
+	if (buffer) {
+		string->buffer = nvd_strdup_wide(buffer);
+		string->len = wcslen(buffer);
+		string->mem_usage =
+			string->len * sizeof(wchar_t) + sizeof(wchar_t);
+	} else {
+		size_t allocsize = (NVD_DEFAULT_WSTRING_LEN * sizeof(wchar_t));
+		string->buffer = nvd_malloc(allocsize + sizeof(wchar_t));
+		string->len = 0;
+		string->mem_usage = allocsize + sizeof(wchar_t);
+		nvd_zero_memory(string->buffer, allocsize + sizeof(wchar_t));
+	}
+
+	return string;
+}
+
+NvdDynamicString *nvd_wide_to_c_str(NvdWideString *str) {
+	if (!str || !str->buffer) return NULL;
+
+	size_t needed = wcstombs(NULL, str->buffer, 0);
+	if (needed == (size_t)-1) return NULL;
+
+	char *buffer = nvd_malloc(needed + 1);
+	wcstombs(buffer, str->buffer, needed + 1);
+
+	NvdDynamicString *out = nvd_string_new(buffer);
+	free(buffer);
+	return out;
+}
+
+NVD_API size_t nvd_wide_strlen(NvdWideString *string) {
+	if (!string) return 0;
+	return wcslen(string->buffer);
+}
+
+wchar_t *nvd_get_internal_wide_string(NvdWideString *str) {
+	if (!str) return NULL;
+	return str->buffer;
+}
+
+void nvd_delete_wide_string(NvdWideString *str) {
+	if (!str) return;
+
+	if (str->buffer) free(str->buffer);
+
+	free(str);
+}


### PR DESCRIPTION
Wide characters are common on many operating systems. In addition to their expanded character set and support from `libc`, they will provide better integration with platforms like Windows and macOS that rely on them extensively. In addition, it will make translation for projects much easier, especially those using less common scripts and languages. GNU/Linux and the BSD family will also be able to make use of them.

This PR will add support to NvDialog to work with wide strings. Note that to maintain good ABI compatibility, functions using wide strings will be declared/implemented separately from their regular, C string versions.
