### PR TITLE
wrap all headers (except in `dialogs/`) in a C++ guard

### DIFF
--- a/include/nvdialog_capab.h
+++ b/include/nvdialog_capab.h
@@ -30,6 +30,10 @@
 #include <stdbool.h>
 #include "nvdialog_platform.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 /**
  * @brief Enumerator defining nvdialog optional capabilities. To be used with @ref nvd_get_capabilities
  * @since v0.2.0
@@ -62,5 +66,9 @@ typedef enum {
  * @ingroup Capabilities
  */
 NVD_API bool nvd_get_capabilities(int query);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 
 #endif /* __nvdialog_capab_h__ */

--- a/include/nvdialog_core.h
+++ b/include/nvdialog_core.h
@@ -27,8 +27,11 @@
 #ifndef __nvdialog_core_h__
 #define __nvdialog_core_h__ 1
 
-#include "nvdialog_types.h"
 #include "nvdialog_platform.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /**
  * @brief An opaque representation of a window object.
@@ -139,5 +142,9 @@ NVD_API void nvd_delete_parent(void);
  * @note @ref object may be NULL, although this will print a small warning on the command line.
  */
 NVD_API void nvd_free_object(void *object);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 
 #endif /* __nvdialog_core_h__ */

--- a/include/nvdialog_dialog.h
+++ b/include/nvdialog_dialog.h
@@ -27,9 +27,17 @@
 #ifndef __nvdialog_dialog_h__
 #define __nvdialog_dialog_h__ 1
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 #include "dialogs/nvdialog_about_dialog.h"
 #include "dialogs/nvdialog_dialog_box.h"
 #include "dialogs/nvdialog_file_dialog.h"
 #include "dialogs/nvdialog_input_box.h"
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 
 #endif /* __nvdialog_dialog_h__ */

--- a/include/nvdialog_error.h
+++ b/include/nvdialog_error.h
@@ -24,11 +24,15 @@
 
 #pragma once
 
-#include "nvdialog_string.h"
 #ifndef __nvdialog_error_h__
 #define __nvdialog_error_h__ 1
 
 #include "nvdialog_platform.h"
+#include "nvdialog_string.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /**
  * @brief An enumerator describing possible errors that may occur from the library.
@@ -73,5 +77,9 @@ NVD_API NvdError nvd_get_error(void);
  * @note Pre v0.10 code may not work with this function due to different return types.
  */
 NVD_API NvdDynamicString *nvd_stringify_error(NvdError err);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 
 #endif /* __nvdialog_error_h__ */

--- a/include/nvdialog_image.h
+++ b/include/nvdialog_image.h
@@ -31,8 +31,10 @@
 #include <stddef.h>
 #include <stdint.h>
 #include "nvdialog_platform.h"
-#include "nvdialog_types.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /**
  * @brief Data that can be interpeted as an image.
@@ -95,5 +97,9 @@ NVD_API void nvd_destroy_image(NvdImage *image);
  * @since v0.10.1
  */
 NVD_API uint8_t *nvd_image_to_bytes(NvdImage *image);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 
 #endif /* __nvdialog_image_h__ */

--- a/include/nvdialog_notification.h
+++ b/include/nvdialog_notification.h
@@ -29,6 +29,10 @@
 
 #include "nvdialog_platform.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 /**
  * @brief Possible types of NvDialog notifications. Each field will create a
  * slightly different dialog matching the requested type.
@@ -120,4 +124,9 @@ NVD_API void nvd_delete_notification(NvdNotification* notification);
 NVD_API void nvd_add_notification_action(NvdNotification* notification,
                                          const char* action, int value_to_set,
                                          int* value_to_return);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
 #endif /* __nvdialog_notification_h__ */

--- a/include/nvdialog_platform.h
+++ b/include/nvdialog_platform.h
@@ -25,6 +25,10 @@
 #ifndef __nvdialog_platform_h__
 #define __nvdialog_platform_h__ (1)
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 #if !defined(NVD_API_EXPORT) && !defined(NVD_API_IMPORT) && !defined(NVD_API) && !defined(NVD_STATIC_LINKAGE)
 
 #if defined(_WIN32) || defined(WIN32)
@@ -59,5 +63,9 @@
 #if !defined(NVD_API)
 #define NVD_API
 #endif /* !defined(NVD_API) */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 
 #endif /* __nvdialog_platform_h__ */

--- a/include/nvdialog_string.h
+++ b/include/nvdialog_string.h
@@ -30,6 +30,10 @@
 #include <stddef.h>
 #include "nvdialog_platform.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 /**
  * @brief A shortcut macro to create a new @ref NvdDynamicString out of a simple string.
  * @since v0.10
@@ -152,5 +156,9 @@ NVD_API void nvd_string_clear(NvdDynamicString *string);
  * @ingroup String
 */
 NVD_API void nvd_delete_string(NvdDynamicString *string);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 
 #endif /* __nvdialog_string_h__ */

--- a/include/nvdialog_types.h
+++ b/include/nvdialog_types.h
@@ -27,6 +27,10 @@
 #ifndef __nvdialog_types_h__
 #define __nvdialog_types_h__ 1
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 /**
  * @brief Defines what use it the dialog about.
  * Each member of this enum defines what the dialog should
@@ -88,5 +92,9 @@ typedef struct {
         char *string; /**< String representation of the version for eg. printf()
                          calls. */
 } NvdVersion;
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 
 #endif /* __nvdialog_types_h__ */


### PR DESCRIPTION
I do like this library a lot and actively use it in my program [oshot](https://github.com/Toni500github/oshot), but something that annoys me everytime is when I include a specific header instead of `nvdialog.h` and then all my builds fails because I forgot to include it inside a `extern "C"` guard.

This PR fixes this. Didn't wrap the headers in `dialogs/` because they don't have an include guard and seems like they are obligated to be used with `nvdialog_dialogs.h`, so I guess fair enough