### PR TITLE
Potential fix for code scanning alert no. 10: Multiplication result converted to larger type

### DIFF
--- a/src/nvdialog_image.c
+++ b/src/nvdialog_image.c
@@ -68,7 +68,7 @@ NvdImage *nvd_create_image(const uint8_t *data, int width, int height) {
         NVD_ASSERT(data != NULL);
 
         image->data = data;
-        image->len = 4 * (unsigned int) (width * height);
+        image->len = ((size_t)4) * (size_t)width * (size_t)height;
         image->width = width;
         image->height = height;
 


### PR DESCRIPTION
Potential fix for [https://github.com/tseli0s/nvdialog/security/code-scanning/10](https://github.com/tseli0s/nvdialog/security/code-scanning/10)

The best fix is to perform the size computation in `size_t` arithmetic from the first multiplication operand, so no intermediate `int`/`unsigned int` overflow occurs before assignment.

In `src/nvdialog_image.c`, update line 71 in `nvd_create_image`:

- Replace `4 * (unsigned int) (width * height)`  
- With `((size_t)4) * (size_t)width * (size_t)height`

This preserves functionality (bytes = 4 channels × width × height) while ensuring the multiplication is carried out in `size_t`. No new imports are needed because `<stdlib.h>` is already included and `size_t` is available.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
